### PR TITLE
#167651655 Add cancel trip endpoint feature

### DIFF
--- a/server/api/controllers/tripController.js
+++ b/server/api/controllers/tripController.js
@@ -26,6 +26,15 @@ const TripController = {
         }
         return res.status(200).json({ status: 'success', data: specificTrip});
     },
+
+    cancelTrip(req, res) {
+        const id = parseInt(req.params.id);
+        const cancelTrip = Trip.cancelTrip(id);
+        if(!cancelTrip) {
+            return res.status(404).json ({ status: 'error', error: 'Not found'});
+        }
+        return res.status(200).json({ status: 'success', data: cancelTrip});
+    },
 };
 
 export default TripController;

--- a/server/api/routes/index.js
+++ b/server/api/routes/index.js
@@ -13,5 +13,6 @@ router.post('/auth/signin', SignIn.signin);
 router.post('/trips', Trip.createNewTrip);
 router.get('/trips', Trip.getAllTrips);
 router.get('/trips/:id', Trip.getSpecificTrip);
+router.patch('/trips/:id/cancel', Trip.cancelTrip);
 
 export default router;

--- a/server/test/trips.test.js
+++ b/server/test/trips.test.js
@@ -65,4 +65,27 @@ describe('Trip Tests', () => {
         done();
         });
     });
+
+    // CANCEL A TRIP TEST
+    it('PATCH/api/v1/trips/:trip-id/cancel Should cancel all trips', (done) => {
+        const trip = {
+            id: Trip.getAllTrips().length + 1,
+            seating_capacity: 67,
+            bus_license_number: 'KZE432Y',
+            origin: 'Nairobi',
+            destination: 'Kigali',
+            trip_date: '23-07-2019',
+            fare: 4000,
+            status: 1,
+        };
+        const tripId = Trip.createNewTrip(trip).id;
+        chai
+        .request(app)
+        .patch(`/api/v1/trips/${tripId}/cancel`)
+        .end((err, res) => {
+        res.should.have.status(200);
+        res.should.should.be.a('object');
+        done();
+        });
+    });
 });


### PR DESCRIPTION
#### What does this PR do?
Adds cancel trip endpoint feature

#### Description of Task to be completed?
- Add tests for cancel trip endpoint 
- Add model for cancel trip
- Add cancel trip controller
-Add cancel trip endpoint route

#### How should this be manually tested?
Clone this repository and run `npm install && npm run test`

#### Any background context you want to provide?
Adding a cancel trip endpoint feature that will enable users to cancel a trip if they so wish. 

#### What are the relevant pivotal tracker stories?
As a user, I should be able to cancel a trip 